### PR TITLE
Only get subtitles where defaultOn: True

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nrkdownload"
-version = "3.1.1"
+version = "3.1.2"
 description = ""
 authors = ["Martin Høy <marhoy@gmail.com>"]
 readme = "README.md"

--- a/src/nrkdownload/nrk_tv.py
+++ b/src/nrkdownload/nrk_tv.py
@@ -79,7 +79,9 @@ class TVProgram(BaseModel):
             backdrop_url=get_image_url(data, "backdropImage"),
             media_urls=[asset["url"] for asset in manifest["playable"]["assets"]],
             subtitle_urls=[
-                title["webVtt"] for title in manifest["playable"]["subtitles"]
+                title["webVtt"]
+                for title in manifest["playable"]["subtitles"]
+                if title["defaultOn"]
             ],
         )
 


### PR DESCRIPTION
Fix problem where a program has multiple subtitles files because some of the spoken language is foreign.
We now only get the subtitle file where `defaultOn: True`